### PR TITLE
feat: Add existing and new Celery scripts to version control

### DIFF
--- a/celery_worker_scripts/crontab
+++ b/celery_worker_scripts/crontab
@@ -1,0 +1,20 @@
+# Start the harmonisation pipeline for GWAS-SSF:
+0 10 * * * . $HOME/.bash_profile; /hps/software/users/parkinso/spot/gwas/prod/scripts/cron/start_harmonisation.sh
+# Start the harmonisation pipeline for pre-GWAS-SSF:
+0 10 * * * . $HOME/.bash_profile; /hps/software/users/parkinso/spot/gwas/prod/scripts/cron/start_harmonisation_pre_standard.sh
+
+#Celery worker start for sumstats service (SANDBOX):
+0 10 */3 * * . $HOME/.bash_profile; /hps/software/users/parkinso/spot/gwas/dev/scripts/cron/sumstats_service/start_celery_worker.sh
+#Celery worker start for sumstats service (PROD):
+0 10 */3 * * . $HOME/.bash_profile; /hps/software/users/parkinso/spot/gwas/prod/scripts/cron/sumstats_service/start_celery_worker.sh
+# Set permissions on deposited files
+0 22 * * * . $HOME/.bash_profile; chmod -R g+w /hps/nobackup/parkinso/spot/gwas/data/sumstats/depo/staging/
+
+# refresh harmonisation queue
+0 17 * * * . $HOME/.bash_profile; /hps/software/users/parkinso/spot/gwas/prod/sw/harmonisation/refresh_hq.sh
+
+# queue GWAS-SSF files for harmonisation
+0 19 * * * . $HOME/.bash_profile; /hps/software/users/parkinso/spot/gwas/prod/sw/harmonisation/release_gwas_ssf.sh
+
+# queue pre-GWAS-SSF files for harmonisation 
+0 20 * * * . $HOME/.bash_profile; /hps/software/users/parkinso/spot/gwas/prod/sw/harmonisation/release_pre_gwas_ssf.sh

--- a/celery_worker_scripts/dev/START_CELERY_WORKERS.sh
+++ b/celery_worker_scripts/dev/START_CELERY_WORKERS.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+COMMIT_SHA=$1
+
+ENV_FILE="/hps/software/users/parkinso/spot/gwas/dev/scripts/cron/sumstats_service/cel_envs_sandbox"
+LOG_LEVEL="info"
+MEM="8000"
+CLUSTER_QUEUE="standard"
+
+source $ENV_FILE
+
+# Module install cmd
+lmod_cmd="module load singularity-3.6.4-gcc-9.3.0-yvkwp5n; module load openjdk-16.0.2-gcc-9.3.0-xyn6nf5; module load nextflow-21.10.6-gcc-9.3.0-tkuemwd"
+
+# pull Singularity image
+
+if [ ! -z "${COMMIT_SHA}" ];
+then
+	sed -i "s/SINGULARITY_TAG=.*/SINGULARITY_TAG=\"${COMMIT_SHA}\"/g" $ENV_FILE
+	singularity pull --dir $SINGULARITY_CACHEDIR docker://${SINGULARITY_REPO}/${SINGULARITY_IMAGE}:${COMMIT_SHA}
+	SINGULARITY_TAG=$COMMIT_SHA
+else
+	echo "not set"
+fi
+
+# Set Singularity cmd
+singularity_cmd="singularity exec --env-file $ENV_FILE $SINGULARITY_CACHEDIR/gwas-sumstats-service_${SINGULARITY_TAG}.sif"
+
+# Set celery worker cmd
+celery_cmd="celery -A sumstats_service.app.celery worker --loglevel=${LOG_LEVEL} --queues=${CELERY_QUEUE1},${CELERY_QUEUE2}"
+
+# Warm shutdown existing celery workers
+bkill -g /depo_validation 0
+
+# Submit new celery workers
+for WORKER_ID in {1..2}; do
+	bsub -g /depo_validation -oo "cel_${WORKER_ID}.o" -eo "cel_${WORKER_ID}.e" -q ${CLUSTER_QUEUE} -M ${MEM} -R "rusage[mem=${MEM}]" "${lmod_cmd}; ${singularity_cmd} ${celery_cmd}"
+done

--- a/celery_worker_scripts/dev/START_CELERY_WORKERS_SLURM.sh
+++ b/celery_worker_scripts/dev/START_CELERY_WORKERS_SLURM.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+COMMIT_SHA=$1
+
+ENV_FILE="/hps/software/users/parkinso/spot/gwas/dev/scripts/cron/sumstats_service/cel_envs_sandbox"
+LOG_LEVEL="info"
+MEM="8000"
+CLUSTER_QUEUE="standard"
+
+source $ENV_FILE
+
+# Module install cmd
+lmod_cmd="module load singularity-3.6.4-gcc-9.3.0-yvkwp5n; module load openjdk-16.0.2-gcc-9.3.0-xyn6nf5; module load nextflow-21.10.6-gcc-9.3.0-tkuemwd"
+
+# pull Singularity image
+
+if [ ! -z "${COMMIT_SHA}" ];
+then
+    sed -i "s/SINGULARITY_TAG=.*/SINGULARITY_TAG=\"${COMMIT_SHA}\"/g" $ENV_FILE
+    singularity pull --dir $SINGULARITY_CACHEDIR docker://${SINGULARITY_REPO}/${SINGULARITY_IMAGE}:${COMMIT_SHA}
+    SINGULARITY_TAG=$COMMIT_SHA
+else
+    echo "not set"
+fi
+
+# Set Singularity cmd
+singularity_cmd="singularity exec --env-file $ENV_FILE $SINGULARITY_CACHEDIR/gwas-sumstats-service_${SINGULARITY_TAG}.sif"
+
+# Set celery worker cmd
+celery_cmd="celery -A sumstats_service.app.celery worker --loglevel=${LOG_LEVEL} --queues=${CELERY_QUEUE1},${CELERY_QUEUE2}"
+
+# Shutdown gracefully all jobs named sumstats_service_celery_worker
+# --full is required because "By default, signals other than SIGKILL 
+# are not sent to the batch step (the shell script). With this 
+# option scancel also signals the batch script and its children processes."
+# See https://slurm.schedmd.com/scancel.html#OPT_full
+scancel --name=sumstats_service_celery_worker --signal=TERM --full
+
+# Submit new SLURM jobs for celery workers
+for WORKER_ID in {1..2}; do
+    sbatch --parsable --output="cel_${WORKER_ID}.o" --error="cel_${WORKER_ID}.e" --mem=${MEM} --time=7-00:00:00 --job-name=sumstats_service_celery_worker --wrap="${lmod_cmd}; ${singularity_cmd} ${celery_cmd}"
+done

--- a/celery_worker_scripts/dev/start_celery_worker.sh
+++ b/celery_worker_scripts/dev/start_celery_worker.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+ENV_FILE="/hps/software/users/parkinso/spot/gwas/dev/scripts/cron/sumstats_service/cel_envs_sandbox"
+LOG_LEVEL="info"
+MEM="8000"
+CLUSTER_QUEUE="standard"
+
+source $ENV_FILE
+
+# Module install cmd
+lmod_cmd="module load singularity-3.6.4-gcc-9.3.0-yvkwp5n; module load openjdk-16.0.2-gcc-9.3.0-xyn6nf5; module load nextflow-21.10.6-gcc-9.3.0-tkuemwd"
+
+# Set Singularity cmd
+singularity_cmd="singularity exec --env-file $ENV_FILE $SINGULARITY_CACHEDIR/gwas-sumstats-service_${SINGULARITY_TAG}.sif"
+
+# Set celery worker cmd
+celery_cmd="celery -A sumstats_service.app.celery worker --loglevel=${LOG_LEVEL} --queues=${CELERY_QUEUE1},${CELERY_QUEUE2}"
+
+# Warm shutdown existing celery workers
+bkill -g /depo_validation 0
+
+# Submit new celery workers
+for WORKER_ID in {1..2}; do
+	bsub -g /depo_validation -oo "cel_${WORKER_ID}.o" -eo "cel_${WORKER_ID}.e" -q ${CLUSTER_QUEUE} -M ${MEM} -R "rusage[mem=${MEM}]" "${lmod_cmd}; ${singularity_cmd} ${celery_cmd}"
+done

--- a/celery_worker_scripts/dev/start_celery_worker_slurm.sh
+++ b/celery_worker_scripts/dev/start_celery_worker_slurm.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+ENV_FILE="/hps/software/users/parkinso/spot/gwas/dev/scripts/cron/sumstats_service/cel_envs_sandbox"
+LOG_LEVEL="info"
+MEM="8000"
+CLUSTER_QUEUE="standard"
+
+source $ENV_FILE
+
+# Module install cmd
+lmod_cmd="module load singularity-3.6.4-gcc-9.3.0-yvkwp5n; module load openjdk-16.0.2-gcc-9.3.0-xyn6nf5; module load nextflow-21.10.6-gcc-9.3.0-tkuemwd"
+
+# Set Singularity cmd
+singularity_cmd="singularity exec --env-file $ENV_FILE $SINGULARITY_CACHEDIR/gwas-sumstats-service_${SINGULARITY_TAG}.sif"
+
+# Set celery worker cmd
+celery_cmd="celery -A sumstats_service.app.celery worker --loglevel=${LOG_LEVEL} --queues=${CELERY_QUEUE1},${CELERY_QUEUE2}"
+
+# Shutdown gracefully all jobs named sumstats_service_celery_worker
+# --full is required because "By default, signals other than SIGKILL 
+# are not sent to the batch step (the shell script). With this 
+# option scancel also signals the batch script and its children processes."
+# See https://slurm.schedmd.com/scancel.html#OPT_full
+scancel --name=sumstats_service_celery_worker --signal=TERM --full
+
+# Submit new SLURM jobs for celery workers
+for WORKER_ID in {1..2}; do
+    sbatch --parsable --output="cel_${WORKER_ID}.o" --error="cel_${WORKER_ID}.e" --mem=${MEM} --time=7-00:00:00 --job-name=sumstats_service_celery_worker --wrap="${lmod_cmd}; ${singularity_cmd} ${celery_cmd}"
+done

--- a/celery_worker_scripts/prod/START_CELERY_WORKERS.sh
+++ b/celery_worker_scripts/prod/START_CELERY_WORKERS.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+
+ENV_FILE="/hps/software/users/parkinso/spot/gwas/prod/scripts/cron/sumstats_service/cel_envs_hx"
+LOG_LEVEL="info"
+MEM="8000"
+CLUSTER_QUEUE="standard"
+
+source $ENV_FILE
+
+# Module install cmd
+lmod_cmd="module load singularity-3.6.4-gcc-9.3.0-yvkwp5n; module load openjdk-16.0.2-gcc-9.3.0-xyn6nf5; module load nextflow-21.10.6-gcc-9.3.0-tkuemwd"
+
+# pull Singularity image
+
+singularity pull --dir $SINGULARITY_CACHEDIR --force  docker://${SINGULARITY_REPO}/${SINGULARITY_IMAGE}:latest
+
+# Set Singularity cmd
+singularity_cmd="singularity exec --env-file $ENV_FILE $SINGULARITY_CACHEDIR/gwas-sumstats-service_latest.sif"
+
+# Set celery worker cmd
+celery_cmd="celery -A sumstats_service.app.celery worker --loglevel=${LOG_LEVEL} --queues=${CELERY_QUEUE1},${CELERY_QUEUE2}"
+
+
+# Warm shutdown existing celery workers
+bkill -g /depo_validation_prod 0
+
+# Submit new celery workers
+echo "spinning up HX celery workers:"
+for WORKER_ID in {1..3}; do
+	echo $WORKER_ID
+	bsub -g /depo_validation_prod -oo "cel_${WORKER_ID}.o" -eo "cel_${WORKER_ID}.e" -q ${CLUSTER_QUEUE} -M ${MEM} -R "rusage[mem=${MEM}]" "${lmod_cmd}; ${singularity_cmd} ${celery_cmd}"
+done
+
+# spin up the workers for hl rabbitmq
+ENV_FILE="/hps/software/users/parkinso/spot/gwas/prod/scripts/cron/sumstats_service/cel_envs_hh"
+singularity_cmd="singularity exec --env-file $ENV_FILE $SINGULARITY_CACHEDIR/gwas-sumstats-service_latest.sif"
+
+echo "spinning up HH celery workers:"
+for WORKER_ID in {4..6}; do
+	echo $WORKER_ID
+        bsub -g /depo_validation_prod -oo "cel_${WORKER_ID}.o" -eo "cel_${WORKER_ID}.e" -q ${CLUSTER_QUEUE} -M ${MEM} -R "rusage[mem=${MEM}]" "${lmod_cmd}; ${singularity_cmd} ${celery_cmd}"
+done

--- a/celery_worker_scripts/prod/START_CELERY_WORKERS_SLURM.sh
+++ b/celery_worker_scripts/prod/START_CELERY_WORKERS_SLURM.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+ENV_FILE="/hps/software/users/parkinso/spot/gwas/prod/scripts/cron/sumstats_service/cel_envs_hx"
+LOG_LEVEL="info"
+MEM="8000"
+CLUSTER_QUEUE="standard"
+
+source $ENV_FILE
+
+# Module install cmd
+lmod_cmd="module load singularity-3.6.4-gcc-9.3.0-yvkwp5n; module load openjdk-16.0.2-gcc-9.3.0-xyn6nf5; module load nextflow-21.10.6-gcc-9.3.0-tkuemwd"
+
+# pull Singularity image
+singularity pull --dir $SINGULARITY_CACHEDIR --force  docker://${SINGULARITY_REPO}/${SINGULARITY_IMAGE}:latest
+
+# Set Singularity cmd
+singularity_cmd="singularity exec --env-file $ENV_FILE $SINGULARITY_CACHEDIR/gwas-sumstats-service_latest.sif"
+
+# Set celery worker cmd
+celery_cmd="celery -A sumstats_service.app.celery worker --loglevel=${LOG_LEVEL} --queues=${CELERY_QUEUE1},${CELERY_QUEUE2}"
+
+# Shutdown gracefully all jobs named sumstats_service_celery_worker
+# --full is required because "By default, signals other than SIGKILL 
+# are not sent to the batch step (the shell script). With this 
+# option scancel also signals the batch script and its children processes."
+# See https://slurm.schedmd.com/scancel.html#OPT_full
+scancel --name=sumstats_service_celery_worker_prod --signal=TERM --full
+
+# Submit new SLURM jobs for HX celery workers
+for WORKER_ID in {1..3}; do
+    sbatch --parsable --output="cel_${WORKER_ID}.o" --error="cel_${WORKER_ID}.e" --mem=${MEM} --time=7-00:00:00 --job-name=sumstats_service_celery_worker_prod --wrap="${lmod_cmd}; ${singularity_cmd} ${celery_cmd}"
+done
+
+# spin up the workers for hl rabbitmq
+ENV_FILE="/hps/software/users/parkinso/spot/gwas/prod/scripts/cron/sumstats_service/cel_envs_hh"
+singularity_cmd="singularity exec --env-file $ENV_FILE $SINGULARITY_CACHEDIR/gwas-sumstats-service_latest.sif"
+
+# Submit new SLURM jobs for HH celery workers
+for WORKER_ID in {4..6}; do
+    sbatch --parsable --output="cel_${WORKER_ID}.o" --error="cel_${WORKER_ID}.e" --mem=${MEM} --time=7-00:00:00 --job-name=sumstats_service_celery_worker_prod --wrap="${lmod_cmd}; ${singularity_cmd} ${celery_cmd}"
+done

--- a/celery_worker_scripts/prod/start_celery_worker.sh
+++ b/celery_worker_scripts/prod/start_celery_worker.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+ENV_FILE="/hps/software/users/parkinso/spot/gwas/prod/scripts/cron/sumstats_service/cel_envs_hx"
+LOG_LEVEL="info"
+MEM="8000"
+CLUSTER_QUEUE="standard"
+
+source $ENV_FILE
+
+# Module install cmd
+lmod_cmd="module load singularity-3.6.4-gcc-9.3.0-yvkwp5n; module load openjdk-16.0.2-gcc-9.3.0-xyn6nf5; module load nextflow-21.10.6-gcc-9.3.0-tkuemwd"
+
+# Set Singularity cmd
+singularity_cmd="singularity exec --env-file $ENV_FILE $SINGULARITY_CACHEDIR/gwas-sumstats-service_latest.sif"
+
+# Set celery worker cmd
+celery_cmd="celery -A sumstats_service.app.celery worker --loglevel=${LOG_LEVEL} --queues=${CELERY_QUEUE1},${CELERY_QUEUE2}"
+
+# Warm shutdown existing celery workers
+bkill -g /depo_validation_prod 0
+
+# Submit new celery workers
+for WORKER_ID in {1..3}; do
+	bsub -g /depo_validation_prod -oo "cel_${WORKER_ID}.o" -eo "cel_${WORKER_ID}.e" -q ${CLUSTER_QUEUE} -W 72:00 -M ${MEM} -R "rusage[mem=${MEM}]" "${lmod_cmd}; ${singularity_cmd} ${celery_cmd}"
+done
+
+# spin up the workers for hl rabbitmq
+ENV_FILE="/hps/software/users/parkinso/spot/gwas/prod/scripts/cron/sumstats_service/cel_envs_hh"
+singularity_cmd="singularity exec --env-file $ENV_FILE $SINGULARITY_CACHEDIR/gwas-sumstats-service_latest.sif"
+
+for WORKER_ID in {4..6}; do
+        bsub -g /depo_validation_prod -oo "cel_${WORKER_ID}.o" -eo "cel_${WORKER_ID}.e" -q ${CLUSTER_QUEUE} -W 72:00 -M ${MEM} -R "rusage[mem=${MEM}]" "${lmod_cmd}; ${singularity_cmd} ${celery_cmd}"
+done

--- a/celery_worker_scripts/prod/start_celery_worker_slurm.sh
+++ b/celery_worker_scripts/prod/start_celery_worker_slurm.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+ENV_FILE="/hps/software/users/parkinso/spot/gwas/prod/scripts/cron/sumstats_service/cel_envs_hx"
+LOG_LEVEL="info"
+MEM="8000"
+CLUSTER_QUEUE="standard"
+
+source $ENV_FILE
+
+# Module install cmd
+lmod_cmd="module load singularity-3.6.4-gcc-9.3.0-yvkwp5n; module load openjdk-16.0.2-gcc-9.3.0-xyn6nf5; module load nextflow-21.10.6-gcc-9.3.0-tkuemwd"
+
+# Set Singularity cmd
+singularity_cmd="singularity exec --env-file $ENV_FILE $SINGULARITY_CACHEDIR/gwas-sumstats-service_latest.sif"
+
+# Set celery worker cmd
+celery_cmd="celery -A sumstats_service.app.celery worker --loglevel=${LOG_LEVEL} --queues=${CELERY_QUEUE1},${CELERY_QUEUE2}"
+
+# Shutdown gracefully all jobs named sumstats_service_celery_worker
+# --full is required because "By default, signals other than SIGKILL 
+# are not sent to the batch step (the shell script). With this 
+# option scancel also signals the batch script and its children processes."
+# See https://slurm.schedmd.com/scancel.html#OPT_full
+scancel --name=sumstats_service_celery_worker_prod --signal=TERM --full
+
+# Submit new SLURM jobs for HX celery workers
+for WORKER_ID in {1..3}; do
+    sbatch --parsable --output="cel_${WORKER_ID}.o" --error="cel_${WORKER_ID}.e" --mem=${MEM} --time=7-00:00:00 --job-name=sumstats_service_celery_worker_prod --wrap="${lmod_cmd}; ${singularity_cmd} ${celery_cmd}"
+done
+
+# spin up the workers for hl rabbitmq
+ENV_FILE="/hps/software/users/parkinso/spot/gwas/prod/scripts/cron/sumstats_service/cel_envs_hh"
+singularity_cmd="singularity exec --env-file $ENV_FILE $SINGULARITY_CACHEDIR/gwas-sumstats-service_latest.sif"
+
+# Submit new SLURM jobs for HH celery workers
+for WORKER_ID in {4..6}; do
+    sbatch --parsable --output="cel_${WORKER_ID}.o" --error="cel_${WORKER_ID}.e" --mem=${MEM} --time=7-00:00:00 --job-name=sumstats_service_celery_worker_prod --wrap="${lmod_cmd}; ${singularity_cmd} ${celery_cmd}"
+done

--- a/celery_worker_scripts/scrontab
+++ b/celery_worker_scripts/scrontab
@@ -1,0 +1,30 @@
+# Welcome to scrontab, Slurm's cron-like interface.
+#
+# Edit this file to submit recurring jobs to be run by Slurm.
+#
+# Note that jobs will be run based on the Slurm controller's
+# time and timezone.
+#
+# Lines must either be valid entries, comments (start with '#'),
+# or blank.
+#
+# Lines starting with #SCRON will be parsed for options to use
+# with the next cron line. E.g., "#SCRON --time 1" would request
+# a one minute timelimit be applied. See the sbatch man page for
+# options, although note that not all options are supported here.
+#
+# For example, the following line (when uncommented) would request
+# a job be run at 5am each day.
+# 0 5 * * * /my/script/to/run
+#
+# min hour day-of-month month day-of-week command
+
+#SCRON -t 1
+#SCRON --mem=1
+
+
+# Celery worker start for sumstats service (SANDBOX):
+0 10 */3 * * sbatch --mem=1200M --time=00:30:00 -o /hps/software/users/parkinso/spot/gwas/dev/scripts/cron/sumstats_service/deploy.out -e /hps/software/users/parkinso/spot/gwas/dev/scripts/cron/sumstats_service/deploy.err  --wrap="/hps/software/users/parkinso/spot/gwas/dev/scripts/cron/sumstats_service/start_celery_worker_slurm.sh"
+
+# Celery worker start for sumstats service (PROD):
+0 10 */3 * * sbatch --mem=1200M --time=02:00:00 -o /hps/software/users/parkinso/spot/gwas/prod/scripts/cron/sumstats_service/deploy.out -e /hps/software/users/parkinso/spot/gwas/prod/scripts/cron/sumstats_service/deploy.err  --wrap="/hps/software/users/parkinso/spot/gwas/prod/scripts/cron/sumstats_service/start_celery_worker_slurm.sh"


### PR DESCRIPTION
## What?
Introduce existing and new Celery scripts to the repository.

## Why?
Without version control, tracking changes and discussing modifications to these scripts is challenging. Adding them to GitHub allows for better historical tracking and collaborative development.

## How?
The integration includes pre-existing scripts used in the LSF environment. Celery workers are managed through `celery_worker_scripts/<env>/START_CELERY_WORKERS.sh`, which are refreshed every three days via crontab using `celery_worker_scripts/<env>/start_celery_worker.sh`. For the upcoming SLURM migration, new scripts ending in `_SLURM.sh` or `_slurm.sh` are added, alongside the implementation of scrontab to manage these tasks.

## Testing?
In the development environment, the scripts are tested with shorter cron intervals (2-3 minutes) to ensure functionality. One can test validation as well since the NF executor name is set to `slurm` now.

For production, initiating scrontab before the data release won't impact the current LSF setup, allowing for a safe testing environment. Monitoring the health of celery workers post-implementation will be key to ensuring successful deployment.