### PR TITLE
fix: Generate and backup Celery worker logs in the correct dir

### DIFF
--- a/celery_worker_scripts/prod/start_celery_worker_slurm.sh
+++ b/celery_worker_scripts/prod/start_celery_worker_slurm.sh
@@ -14,7 +14,7 @@ lmod_cmd="module load singularity-3.6.4-gcc-9.3.0-yvkwp5n; module load openjdk-1
 singularity_cmd="singularity exec --env-file $ENV_FILE --bind /usr/lib64/libmunge.so.2:/usr/lib/x86_64-linux-gnu/libmunge.so.2 --bind /var/run/munge:/var/run/munge $SINGULARITY_CACHEDIR/gwas-sumstats-service_latest.sif"
 
 # Set celery worker cmd
-celery_cmd="celery -A sumstats_service.app.celery worker --loglevel=${LOG_LEVEL} --queues=${CELERY_QUEUE1},${CELERY_QUEUE2},${CELERY_QUEUE3} > celery_worker_slurm_prod.log 2>&1"
+celery_cmd="celery -A sumstats_service.app.celery worker --loglevel=${LOG_LEVEL} --queues=${CELERY_QUEUE1},${CELERY_QUEUE2},${CELERY_QUEUE3} > /hps/software/users/parkinso/spot/gwas/prod/scripts/cron/sumstats_service/celery_worker_slurm_prod.log 2>&1"
 
 # Shutdown gracefully all jobs named sumstats_service_celery_worker
 # --full is required because "By default, signals other than SIGKILL 
@@ -24,11 +24,13 @@ celery_cmd="celery -A sumstats_service.app.celery worker --loglevel=${LOG_LEVEL}
 echo "sending SIGTERM signal to prod celery workers"
 scancel --name=sumstats_service_celery_worker_prod --signal=TERM --full
 
+cp /hps/software/users/parkinso/spot/gwas/prod/scripts/cron/sumstats_service/celery_worker_slurm_prod.log /hps/software/users/parkinso/spot/gwas/prod/scripts/cron/sumstats_service/celery_worker_slurm_prod.log.backup
+
 # Submit new SLURM jobs for HX celery workers
 echo "START spinning up HX celery workers:"
 for WORKER_ID in {1..3}; do
     echo $WORKER_ID
-    sbatch --parsable --output="cel_slurm_prod_${WORKER_ID}.o" --error="cel_slurm_prod_${WORKER_ID}.e" --mem=${MEM} --time=7-00:00:00 --job-name=sumstats_service_celery_worker_prod --wrap="${lmod_cmd}; ${singularity_cmd} ${celery_cmd}"
+    sbatch --parsable --output="/hps/software/users/parkinso/spot/gwas/prod/scripts/cron/sumstats_service/cel_slurm_prod_${WORKER_ID}.o" --error="/hps/software/users/parkinso/spot/gwas/prod/scripts/cron/sumstats_service/cel_slurm_prod_${WORKER_ID}.e" --mem=${MEM} --time=7-00:00:00 --job-name=sumstats_service_celery_worker_prod --wrap="${lmod_cmd}; ${singularity_cmd} ${celery_cmd}"
 done
 echo "DONE spinning up HX celery workers"
 
@@ -40,6 +42,6 @@ singularity_cmd="singularity exec --env-file $ENV_FILE --bind /usr/lib64/libmung
 echo "START spinning up HH celery workers:"
 for WORKER_ID in {4..6}; do
     echo $WORKER_ID
-    sbatch --parsable --output="cel_slurm_prod_${WORKER_ID}.o" --error="cel_slurm_prod_${WORKER_ID}.e" --mem=${MEM} --time=7-00:00:00 --job-name=sumstats_service_celery_worker_prod --wrap="${lmod_cmd}; ${singularity_cmd} ${celery_cmd}"
+    sbatch --parsable --output="/hps/software/users/parkinso/spot/gwas/prod/scripts/cron/sumstats_service/cel_slurm_prod_${WORKER_ID}.o" --error="/hps/software/users/parkinso/spot/gwas/prod/scripts/cron/sumstats_service/cel_slurm_prod_${WORKER_ID}.e" --mem=${MEM} --time=7-00:00:00 --job-name=sumstats_service_celery_worker_prod --wrap="${lmod_cmd}; ${singularity_cmd} ${celery_cmd}"
 done
 echo "DONE spinning up HH celery workers"


### PR DESCRIPTION
**Issue:** [#1340](https://github.com/EBISPOT/goci/issues/1340)

**Problem:**
The first validation failed due to large log files in the `/homes/gwas_lsf` directory. This issue was caused by a bug in the script responsible for restarting Celery workers every 3 days.

**Solution:**
This PR fixes the bug in the script to prevent the accumulation of large log files in the home directory. Also, the most recent log file is backed up. 