### PR TITLE
fix: Remove harmonisation reference field from non-hm yamls

### DIFF
--- a/sumstats_service/resources/api_utils.py
+++ b/sumstats_service/resources/api_utils.py
@@ -549,6 +549,7 @@ def generate_yaml_non_hm(accession_id, is_harmonised_included):
 
     metadata_from_gwas_cat["is_harmonised"] = False
     metadata_from_gwas_cat["is_sorted"] = False
+    metadata_from_gwas_cat["harmonisation_reference"] = None
 
     # Setting default values for keys that may not exist
     default_keys = [


### PR DESCRIPTION
Addressing the issue here: https://github.com/EBISPOT/goci/issues/1490#issuecomment-2534887974